### PR TITLE
Disable automatic Docker build record uploads

### DIFF
--- a/.github/actions/docker-multi-arch-build/action.yaml
+++ b/.github/actions/docker-multi-arch-build/action.yaml
@@ -128,6 +128,8 @@ runs:
     - name: Build and push by digest
       id: build
       uses: docker/build-push-action@v7
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}


### PR DESCRIPTION
docker/build-push-action@v7 automatically uploads a .dockerbuild artifact for every platform and image build. The shared multi-arch action currently leaves that behavior enabled, creating unnecessary retained artifacts across its consumers.

Set DOCKER_BUILD_RECORD_UPLOAD to false on the build-push step. This stops those automatic record uploads while retaining job summaries, image publishing, registry caching, digest artifacts, manifest creation, and downstream outputs.